### PR TITLE
_include_mskip_file: push only pure lines (no multiple "\n")

### DIFF
--- a/lib/ExtUtils/Manifest.pm
+++ b/lib/ExtUtils/Manifest.pm
@@ -501,10 +501,10 @@ sub _include_mskip_file {
         return;
     }
     my @lines = ();
-    push @lines, "\n#!start included $mskip\n";
+    push @lines, "\n", "#!start included $mskip\n";
     push @lines, $_ while <M>;
     close M;
-    push @lines, "#!end included $mskip\n\n";
+    push @lines, "#!end included $mskip\n", "\n";
     return @lines;
 }
 


### PR DESCRIPTION
`sub _include_mskip_file` returns an array of strings that are supposed to be lines.
But [some of them aren't](../blob/ee3f0dcb39a1d1104d5ca92647964940f74140a1/lib/ExtUtils/Manifest.pm#L504):
* `"\n#!start included $mskip\n"`
* `"#!end included $mskip\n\n"`