### PR TITLE
Avoid git stuff and travis-ci.org config file

### DIFF
--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -8,6 +8,8 @@
 \B\.gitignore\b
 \b_darcs\b
 \B\.cvsignore$
+^\.git.*
+
 
 # Avoid VMS specific MakeMaker generated files
 \bDescrip.MMS$
@@ -61,3 +63,6 @@
 
 # Avoid MYMETA files
 ^MYMETA\.
+
+# Avoid travis-ci.org file
+^\.travis.yml


### PR DESCRIPTION
This will MANIFEST.skip the .git repository and the travis config file.