### PR TITLE
Test on Windows with AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+skip_tags: true
+cache:
+  - C:\strawberry
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --installdeps .
+build_script:
+  - perl Makefile.PL
+  - dmake test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,5 @@ install:
   - if not exist "C:\strawberry" cinst strawberryperl
   - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - cd C:\projects\%APPVEYOR_PROJECT_NAME%
-  - cpanm --installdeps .
 build_script:
-  - perl Makefile.PL
-  - dmake test
+  - prove -lr t

--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -64,3 +64,6 @@
 
 # Avoid travis-ci.org file
 ^\.travis.yml
+
+# Avoid AppVeyor file
+^\.?appveyor.yml


### PR DESCRIPTION
I went through a bunch of MANIFEST.SKIP files to add _.appveyor.yml_ entries, so I figured I should add it to this module (which already has one for Travis). Along the way I added an AppVeyor config. I [already have it passing](https://ci.appveyor.com/project/briandfoy/extutils-manifest/build/1.0.3) as my fork.

Someone would need to set up an organization account on AppVeyor or test it through organization membership with their individual account, but that's no big whoop.