### PR TITLE
Account for appveyor configuration file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.ackrc
+!/.appveyor.yml
 /.build/
 !/.gitignore
 /.latest

--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -64,3 +64,6 @@
 
 # Avoid travis-ci.org file
 ^\.travis.yml
+
+# Avoid appveyor.com file
+^\.appveyor.yml


### PR DESCRIPTION
Appveyor is increasingly being used by CPAN authors and maintainers to perform
a basic sanity check on Windows in the same way that travis is used on Linux.
It now makes sense to account for the appveyor configuration file in the same
way we already account for .travis.yml.