### PR TITLE
save full path to default MANIFEST.SKIP

### DIFF
--- a/lib/ExtUtils/Manifest.pm
+++ b/lib/ExtUtils/Manifest.pm
@@ -56,7 +56,7 @@ our $Verbose = defined $ENV{PERL_MM_MANIFEST_VERBOSE} ?
 our $Quiet = 0;
 our $MANIFEST = 'MANIFEST';
 
-our $DEFAULT_MSKIP = File::Spec->catfile( dirname(__FILE__), "$MANIFEST.SKIP" );
+our $DEFAULT_MSKIP = File::Spec->rel2abs(File::Spec->catfile( dirname(__FILE__), "$MANIFEST.SKIP" ));
 
 
 =head1 NAME


### PR DESCRIPTION
The default MANIFEST.SKIP file is in the same directory as the
`Manifest.pm` file. EUM finds it by using `__FILE__`. `__FILE__` will be a
relative path if it is loaded by a relative `@INC` path. This means that
if the current directory is changed, `MANIFEST.SKIP` won't be able to be
found.

Calculate at absolute path to `MANIFEST.SKIP` at module load time, where
`__FILE__` is guaranteed to valid.