### PR TITLE
Skip iCloud placeholder files

### DIFF
--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -52,6 +52,8 @@
 \B\.DS_Store
 # Mac OSX SMB mount metadata files
 \B\._
+# Placeholder files created when iCloud will "optimize Mac storage"
+\.i[cC]loud$
 
 # Avoid Devel::Cover and Devel::CoverX::Covered files.
 \bcover_db\b


### PR DESCRIPTION
macOS's iCloud has a feature to "optimize Mac storage" that replaces the real file with a placeholder file. It looks the same in the Finder but is really this file with .icloud added. When you click on it, it downloads the actual file. So, it's probably smart to not have repos in iCloud, but here we are.