### PR TITLE
Add some MANIFEST.SKIP patterns for bzr/brz

### DIFF
--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -9,6 +9,8 @@
 \B\.gitignore\b
 \b_darcs\b
 \B\.cvsignore$
+\B\.bzr\b
+\B\.bzrignore$
 
 # Avoid VMS specific MakeMaker generated files
 \bDescrip.MMS$
@@ -46,6 +48,7 @@
 \.#
 \.rej$
 \..*\.sw.?$
+\.~\d+~$
 
 # Avoid OS-specific files/dirs
 # Mac OSX metadata


### PR DESCRIPTION
Skip the toplevel .bzr and .bzrignore files

Skip any file named .~1~, .~2~, etc.. as these are created as backup copies by `bzr revert`