### PR TITLE
Expand `~` in #!include path as user homedir

### DIFF
--- a/lib/ExtUtils/Manifest.pm
+++ b/lib/ExtUtils/Manifest.pm
@@ -448,6 +448,10 @@ sub maniskip {
     return sub { $_[0] =~ qr{$opts$regex} };
 }
 
+sub _get_homedir {
+    $^O eq 'MSWin32' && "$]" < 5.016 ? $ENV{HOME} || $ENV{USERPROFILE} : (glob('~'))[0];
+}
+
 # checks for the special directives
 #   #!include_default
 #   #!include /path/to/some/manifest.skip
@@ -466,6 +470,7 @@ sub _check_mskip_directives {
     while (<M>) {
         if (/^#!include\s+(.*)\s*$/) {
             my $external_file = $1;
+            $external_file =~ s/^~/_get_homedir()/e;
             if (my @external = _include_mskip_file($external_file)) {
                 push @lines, @external;
                 warn "Debug: Including external $external_file\n" if $Debug;

--- a/t/Manifest.t
+++ b/t/Manifest.t
@@ -13,7 +13,7 @@ BEGIN {
 }
 chdir 't';
 
-use Test::More tests => 99;
+use Test::More tests => 101;
 use Cwd;
 
 use File::Spec;
@@ -349,7 +349,9 @@ SKIP: {
 my @funky_keys = qw(space space_quote space_backslash space_quote_backslash);
 # test including an external manifest.skip file in MANIFEST.SKIP
 {
-    maniadd({ foo => undef , albatross => undef,
+    local $ENV{HOME} = File::Spec->catdir($cwd, qw(mantest));
+
+    maniadd({ foo => undef, orange => undef, albatross => undef,
               'mymanifest.skip' => undef, 'mydefault.skip' => undef});
     for (@funky_keys) {
         maniadd( {$funky_files{$_} => $_} ) if defined $funky_files{$_};
@@ -360,8 +362,9 @@ my @funky_keys = qw(space space_quote space_backslash space_quote_backslash);
     local $ExtUtils::Manifest::DEFAULT_MSKIP =
          File::Spec->catfile($cwd, qw(mantest mydefault.skip));
     my $skip = File::Spec->catfile($cwd, qw(mantest mymanifest.skip));
+    add_file('global.skip' => "^orange\n");
     add_file('MANIFEST.SKIP' =>
-             "albatross\n#!include $skip\n#!include_default");
+             "albatross\n#!include $skip\n#!include_default\n#!include ~/global.skip");
     my ($res, $warn) = catch_warning( \&skipcheck );
     for (qw(albatross foo foobar mymanifest.skip mydefault.skip)) {
         like( $warn, qr/Skipping \b$_\b/,
@@ -376,7 +379,7 @@ my @funky_keys = qw(space space_quote space_backslash space_quote_backslash);
         }
     }
     ($res, $warn) = catch_warning( \&mkmanifest );
-    for (qw(albatross foo foobar mymanifest.skip mydefault.skip)) {
+    for (qw(albatross foo foobar mymanifest.skip mydefault.skip orange)) {
         like( $warn, qr/Removed from MANIFEST: \b$_\b/,
               "Removed $_ from MANIFEST" );
     }
@@ -394,6 +397,7 @@ my @funky_keys = qw(space space_quote space_backslash space_quote_backslash);
     ok( exists $files->{bar},         'bar included in MANIFEST' );
     ok( ! exists $files->{foobar},    'foobar excluded via mymanifest.skip' );
     ok( ! exists $files->{foo},       'foo excluded via mymanifest.skip' );
+    ok( ! exists $files->{orange},    'orange excluded via global.skip' );
     ok( ! exists $files->{'mymanifest.skip'},
         'mymanifest.skip excluded via mydefault.skip' );
     ok( ! exists $files->{'mydefault.skip'},


### PR DESCRIPTION
This makes it more convenient to have a per-user extension list of skip patterns by permitting e.g.

    #!include ~/.perl/MANIFEST.SKIP