### PR TITLE
Ignore yath files

### DIFF
--- a/lib/ExtUtils/MANIFEST.SKIP
+++ b/lib/ExtUtils/MANIFEST.SKIP
@@ -65,6 +65,10 @@
 # Avoid prove files
 \B\.prove$
 
+# Avoid yath files
+^\.yath-ipc/
+^\.test_info\..+\.json$
+
 # Avoid MYMETA files
 ^MYMETA\.
 


### PR DESCRIPTION
This adds the IPC files from Test2::Harness version 1 and 2 to the default skip list.

@exodist 